### PR TITLE
(MAJOR) remove trailing blank line from GetInput

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
   tag:
     needs: test
     if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,13 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@v3
     - run: go test ./...
+  tag:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Git Semantic Version
+      uses: PaulHatch/semantic-version@v4.0.3
 

--- a/lib/files.go
+++ b/lib/files.go
@@ -21,7 +21,6 @@ func GetInput(filename string) ([]string, error) {
 		result = append(result, s.Text())
 	}
 
-	result = append(result, "")
 	return result, nil
 }
 


### PR DESCRIPTION
The `GetInput()` function always includes a blank line at the end of the slice. I'm not sure why I did this, it probably seemed like a good way to capture the newlne at the end of the file. In practice, I ended up doing silly things like iterating over a slice of input without the last value...

```
	for i, val := range input[:len(input)-1] {
		operands[i] = NodeFromString(val)
	}
```

...or simply ignolring blank lines:

```
		if line == "" {
			continue
		}
```

This PR drops the blank line. Given that it'll break existing code, this is a breaking release.